### PR TITLE
Find mount point using canonical path

### DIFF
--- a/pcp
+++ b/pcp
@@ -308,7 +308,7 @@ def sanitycheck(sourcedir, destdir):
     # The destination might not exist yet, so walk up the path until we find the
     # mountpoint.
     if LSTRIPE or FORCESTRIPE:
-        path = os.path.realpath(destdir)
+        path = realdest
         while not os.path.ismount(path):
             path = os.path.dirname(path)
         fstype = statfs.fstype(path)

--- a/pcp
+++ b/pcp
@@ -308,7 +308,7 @@ def sanitycheck(sourcedir, destdir):
     # The destination might not exist yet, so walk up the path until we find the
     # mountpoint.
     if LSTRIPE or FORCESTRIPE:
-        path = destdir
+        path = os.path.realpath(destdir)
         while not os.path.ismount(path):
             path = os.path.dirname(path)
         fstype = statfs.fstype(path)


### PR DESCRIPTION
When copying Lustre stripe information, the destination directory is checked to ensure that it resides on a Lustre filesystem. However, the original check failed if the destination path contained a symlink.

For example, suppose the destination is "/flush/dest", where "/flush" is a symlink to the mount point "/lustre/flush". The original code walks up the specified destination path until it finds a mount point, which in this case is "/". However, the modified code walks up the canonical path "/lustre/flush/dest", and the mount point is identified correctly as "/lustre/flush".