### PR TITLE
Fixes wtsi-ssg/pcp#13

### DIFF
--- a/pcp
+++ b/pcp
@@ -40,7 +40,6 @@ import math
 import random
 import signal
 import gzip
-from pcplib import parallelwalk
 
 try:
     from pcplib import lustreapi
@@ -48,6 +47,7 @@ try:
 except:
     WITHLUSTRE = False
 
+from pcplib import parallelwalk
 from pcplib import statfs
 from pcplib import safestat
 from collections import deque


### PR DESCRIPTION
A warning about the `fork()` system call is displayed during startup of pcp when running under Open MPI 1.6.5 (or 1.8.4) and python 2.7.9. The warning is caused by an `os.popen` function that is called from within the command `from pcplib import lustreapi`.

The `fork()` call only seems to be a problem if it occurs after MPI is initialised. Because mpi4py is imported by parallelwalk, the `fork()` warning is avoided by importing parallelwalk after lustreapi.
